### PR TITLE
Fix SVG image distortion

### DIFF
--- a/src/Base/Foundation.php
+++ b/src/Base/Foundation.php
@@ -132,7 +132,7 @@ class Foundation {
 	 */
 	public static function fix_svg() {
 		echo '<style type="text/css">
-				.attachment-266x266, .thumbnail img {
+				.attachment-266x266[src$=".svg"], .thumbnail img[src$=".svg"] {
 					width: 100% !important;
 					height: auto !important;
 				}


### PR DESCRIPTION
This pull request fixes an issue where SVG images were being distorted. Previously, all images were being selected instead of just SVG images, which caused the distortion. With this fix, only SVG images are selected, ensuring that they are displayed correctly without any distortions.